### PR TITLE
Fix broken LIMIT clause in query templates.

### DIFF
--- a/dbgen/queries/1.sql
+++ b/dbgen/queries/1.sql
@@ -25,4 +25,3 @@ group by
 order by
 	l_returnflag,
 	l_linestatus;
-:n -1

--- a/dbgen/queries/10.sql
+++ b/dbgen/queries/10.sql
@@ -34,5 +34,5 @@ group by
 	c_address,
 	c_comment
 order by
-	revenue desc;
+	revenue desc
 :n 20

--- a/dbgen/queries/11.sql
+++ b/dbgen/queries/11.sql
@@ -31,4 +31,3 @@ group by
 		)
 order by
 	value desc;
-:n -1

--- a/dbgen/queries/12.sql
+++ b/dbgen/queries/12.sql
@@ -32,4 +32,3 @@ group by
 	l_shipmode
 order by
 	l_shipmode;
-:n -1

--- a/dbgen/queries/13.sql
+++ b/dbgen/queries/13.sql
@@ -24,4 +24,3 @@ group by
 order by
 	custdist desc,
 	c_count desc;
-:n -1

--- a/dbgen/queries/14.sql
+++ b/dbgen/queries/14.sql
@@ -17,4 +17,3 @@ where
 	l_partkey = p_partkey
 	and l_shipdate >= date ':1'
 	and l_shipdate < date ':1' + interval '1' month;
-:n -1

--- a/dbgen/queries/15.sql
+++ b/dbgen/queries/15.sql
@@ -37,4 +37,3 @@ order by
 	s_suppkey;
 
 drop view revenue:s;
-:n -1

--- a/dbgen/queries/16.sql
+++ b/dbgen/queries/16.sql
@@ -34,4 +34,3 @@ order by
 	p_brand,
 	p_type,
 	p_size;
-:n -1

--- a/dbgen/queries/17.sql
+++ b/dbgen/queries/17.sql
@@ -21,4 +21,3 @@ where
 		where
 			l_partkey = p_partkey
 	);
-:n -1

--- a/dbgen/queries/18.sql
+++ b/dbgen/queries/18.sql
@@ -35,5 +35,5 @@ group by
 	o_totalprice
 order by
 	o_totalprice desc,
-	o_orderdate;
+	o_orderdate
 :n 100

--- a/dbgen/queries/19.sql
+++ b/dbgen/queries/19.sql
@@ -39,4 +39,3 @@ where
 		and l_shipmode in ('AIR', 'AIR REG')
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	);
-:n -1

--- a/dbgen/queries/2.sql
+++ b/dbgen/queries/2.sql
@@ -46,5 +46,5 @@ order by
 	s_acctbal desc,
 	n_name,
 	s_name,
-	p_partkey;
+	p_partkey
 :n 100

--- a/dbgen/queries/20.sql
+++ b/dbgen/queries/20.sql
@@ -41,4 +41,3 @@ where
 	and n_name = ':3'
 order by
 	s_name;
-:n -1

--- a/dbgen/queries/21.sql
+++ b/dbgen/queries/21.sql
@@ -42,5 +42,5 @@ group by
 	s_name
 order by
 	numwait desc,
-	s_name;
+	s_name
 :n 100

--- a/dbgen/queries/22.sql
+++ b/dbgen/queries/22.sql
@@ -41,4 +41,3 @@ group by
 	cntrycode
 order by
 	cntrycode;
-:n -1

--- a/dbgen/queries/3.sql
+++ b/dbgen/queries/3.sql
@@ -25,5 +25,5 @@ group by
 	o_shippriority
 order by
 	revenue desc,
-	o_orderdate;
+	o_orderdate
 :n 10

--- a/dbgen/queries/4.sql
+++ b/dbgen/queries/4.sql
@@ -25,4 +25,3 @@ group by
 	o_orderpriority
 order by
 	o_orderpriority;
-:n -1

--- a/dbgen/queries/5.sql
+++ b/dbgen/queries/5.sql
@@ -28,4 +28,3 @@ group by
 	n_name
 order by
 	revenue desc;
-:n -1

--- a/dbgen/queries/6.sql
+++ b/dbgen/queries/6.sql
@@ -13,4 +13,3 @@ where
 	and l_shipdate < date ':1' + interval '1' year
 	and l_discount between :2 - 0.01 and :2 + 0.01
 	and l_quantity < :3;
-:n -1

--- a/dbgen/queries/7.sql
+++ b/dbgen/queries/7.sql
@@ -43,4 +43,3 @@ order by
 	supp_nation,
 	cust_nation,
 	l_year;
-:n -1

--- a/dbgen/queries/8.sql
+++ b/dbgen/queries/8.sql
@@ -41,4 +41,3 @@ group by
 	o_year
 order by
 	o_year;
-:n -1

--- a/dbgen/queries/9.sql
+++ b/dbgen/queries/9.sql
@@ -36,4 +36,3 @@ group by
 order by
 	nation,
 	o_year desc;
-:n -1


### PR DESCRIPTION
Because `qgen` is essentially a find-and-replace, it was outputting PostgreSQL SQL like

```
order by
    l_returnflag, l_linestatus;
limit -1;

order by
    revenue desc;
limit 20;
```

which has the following problems:

1. negative limits don't make sense and are unsupported in most DBMSs, e.g., PostgreSQL mailing list [thread](https://www.postgresql.org/message-id/1197595141.15521.10.camel%40ebony.site) asking if this was a joke, PostgreSQL [commit](https://github.com/postgres/postgres/commit/bfce56eea45b1369b7bb2150a150d1ac109f5073) rejecting negative limits in 2008.
2. the limit clause is not attached to the select.

I have not tested this behavior with the other DBMSs in `tpcd.h`, although a number of those seem to be outdated anyway (e.g., `SQLSERVER` should use `TOP` instead of `rowcount` now).

---

Duplicate of https://github.com/gregrahn/tpch-kit/pull/4 , merging for my own purposes.