### PR TITLE
Fix Q1 mystery INTERVAL syntax.

### DIFF
--- a/dbgen/queries/1.sql
+++ b/dbgen/queries/1.sql
@@ -18,7 +18,7 @@ select
 from
 	lineitem
 where
-	l_shipdate <= date '1998-12-01' - interval ':1' day (3)
+	l_shipdate <= date '1998-12-01' - interval ':1 day (3)'
 group by
 	l_returnflag,
 	l_linestatus


### PR DESCRIPTION
Fix Q1 mystery INTERVAL syntax.

I'm not actually sure what the original `(3)` was going for,
(was it just a broken footnote?)
but it does appear in the TPC-H spec and PostgreSQL will accept this version.

---

At this point, I wonder if anyone has ever used `qgen`.